### PR TITLE
Add link to ruby-pg-url

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ The format here is inspired by a lot of prior art.
     * [Stackato database URLs](http://docs.stackato.com/3.0/user/services/data-services.html#database-url)
     * [Django database URLs](https://github.com/kennethreitz/dj-database-url)
     * [Rails database URLs](https://github.com/glenngillen/rails-database-url)
+    * [Ruby Pg URL](https://bitbucket.org/eradman/ruby-pg-url)
 
 Author
 ------


### PR DESCRIPTION
ruby-pg is the interface backed by most Ruby and PostgreSQL developers,
but it does not support URI connections strings. ruby-pg-url is a light
weight module that enables this capability in any Ruby application.